### PR TITLE
Add `toJSON` method with secret masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ const config = zodotenv({
     driver: ['DB_DRIVER', z.enum(['mysql', 'pgsql', 'sqlite'])],
     tables: ['DB_TABLES', z.preprocess((s) => s.split(','), z.array(z.string()))],
   },
+  credentials: {
+    username: ['USERNAME', z.string()],
+    password: ['PASSWORD', z.string(), { secret: true }],
+  },
 });
 ```
 
@@ -55,6 +59,36 @@ config('database.tables'); // string[]
 
 config('something.which.does.not.exist');
 // ^^^ TypeScript will call you out on this one
+```
+
+### Serialize your configuration with `config.toJSON()`
+You can serialize your entire configuration object to JSON using `config.toJSON()`.
+This is useful for logging or debugging purposes.
+
+```ts
+console.log(JSON.stringify(config.toJSON(), null, 2));
+```
+
+> [!TIP]
+> Any configuration entries marked with `{ secret: true }` will have their values
+> masked when serializing to JSON, ensuring that sensitive information is not exposed.
+
+#### Example output
+```json
+{
+  "name": "my-app",
+  "port": 3000,
+  "http2": true,
+  "database": {
+    "host": "localhost",
+    "driver": "mysql",
+    "tables": ["users", "posts"]
+  },
+  "credentials": {
+    "username": "admin",
+    "password": "*********"
+  }
+}
 ```
 
 ## Tips

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
 import type { z } from 'zod';
 
-export type EnvWithZodType = [string, z.ZodType];
+interface EnvOptions {
+  secret?: boolean;
+}
+
+export type EnvWithZodType = [string, z.ZodType, EnvOptions?];
 
 export interface ZodotenvConfig {
   [name: string]: ZodotenvConfig | EnvWithZodType;

--- a/src/zodotenv.spec.ts
+++ b/src/zodotenv.spec.ts
@@ -102,4 +102,98 @@ describe('zodotenv', () => {
       assert.deepEqual(config('adminCredentials'), { name: 'admin', password: '12345' });
     });
   });
+
+  describe('Serialization', () => {
+    const originalEnv = structuredClone(process.env);
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('serializes the entire configuration object to JSON', () => {
+      process.env.PORT = '3000';
+      process.env.HTTP2 = 'false';
+      process.env.DB_HOST = 'localhost:5432';
+      process.env.DB_DRIVER = 'mysql';
+      process.env.DB_TABLES = 'users,posts';
+      process.env.ADMIN_CREDENTIALS = '{"name": "admin", "password": "secret"}';
+
+      const config = zodotenv({
+        name: ['NAME', z.string().default('my-app')],
+        port: ['PORT', z.coerce.number()],
+        http2: ['HTTP2', z.string().transform((s) => s === 'true')],
+        database: {
+          host: ['DB_HOST', z.string()],
+          driver: ['DB_DRIVER', z.enum(['mysql', 'pgsql', 'sqlite'])],
+          tables: ['DB_TABLES', z.preprocess((s) => String(s).split(','), z.array(z.string()))],
+        },
+        adminCredentials: [
+          'ADMIN_CREDENTIALS',
+          z
+            .string()
+            .transform((s) => JSON.parse(s))
+            .pipe(
+              z.object({
+                name: z.string(),
+                password: z.string(),
+              }),
+            ),
+        ],
+      });
+
+      const expectedConfig = {
+        name: 'my-app',
+        port: 3000,
+        http2: false,
+        database: {
+          host: 'localhost:5432',
+          driver: 'mysql',
+          tables: ['users', 'posts'],
+        },
+        adminCredentials: {
+          name: 'admin',
+          password: 'secret',
+        },
+      };
+
+      assert.deepEqual(config.toJSON(), expectedConfig);
+    });
+
+    it('masks secret values when serializing to JSON', () => {
+      process.env.PORT = '3000';
+      process.env.API_KEY = 'secret-key';
+      process.env.ADMIN_CREDENTIALS = '{"name": "admin", "password": "secret"}';
+
+      const config = zodotenv({
+        name: ['NAME', z.string().default('my-app')],
+        port: ['PORT', z.coerce.number()],
+        apiKey: ['API_KEY', z.string(), { secret: true }],
+        adminCredentials: [
+          'ADMIN_CREDENTIALS',
+          z
+            .string()
+            .transform((s) => JSON.parse(s))
+            .pipe(
+              z.object({
+                name: z.string(),
+                password: z.string(),
+              }),
+            ),
+          { secret: true },
+        ],
+      });
+
+      const expectedConfig = {
+        name: 'my-app',
+        port: 3000,
+        apiKey: '*********',
+        adminCredentials: {
+          name: '*********',
+          password: '*********',
+        },
+      };
+
+      assert.deepEqual(config.toJSON(), expectedConfig);
+    });
+  });
 });

--- a/src/zodotenv.ts
+++ b/src/zodotenv.ts
@@ -18,7 +18,7 @@ export class ZodotenvError extends Error {
 
 const walk = (map: Map<string, unknown>, entry: ZodotenvConfig | EnvWithZodType, prefix = '') => {
   if (Array.isArray(entry)) {
-    const [envName, schema] = entry;
+    const [envName, schema, options] = entry;
 
     assert(
       typeof envName === 'string' && envName.length > 0,
@@ -35,7 +35,7 @@ const walk = (map: Map<string, unknown>, entry: ZodotenvConfig | EnvWithZodType,
       );
     }
 
-    map.set(prefix, data);
+    map.set(prefix, { value: data, secret: options?.secret });
   } else {
     for (const [name, value] of Object.entries(entry)) {
       const newPrefix = prefix ? `${prefix}.${name}` : name;
@@ -44,15 +44,63 @@ const walk = (map: Map<string, unknown>, entry: ZodotenvConfig | EnvWithZodType,
   }
 };
 
+const maskSecretValue = (value: unknown, secret?: boolean) => {
+  if (!secret) {
+    return value;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return '*********';
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const maskedObj = Array.isArray(value) ? [] : {};
+    for (const key in value) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
+        maskedObj[key] = maskSecretValue(value[key], true);
+      }
+    }
+    return maskedObj;
+  }
+
+  return value;
+};
+
 export const zodotenv = <T extends ZodotenvConfig>(config: T) => {
   assert(
     typeof config === 'object',
     new ZodotenvError('The configuration must be defined as an object'),
   );
 
-  const map = new Map<string, unknown>();
+  const map = new Map<string, { value: unknown; secret?: boolean }>();
 
   walk(map, config);
 
-  return <U extends ObjectPathName<T>>(key: U) => map.get(key) as ObjectPathType<T, PathSplit<U>>;
+  const getConfig = <U extends ObjectPathName<T>>(key: U) =>
+    map.get(key)?.value as ObjectPathType<T, PathSplit<U>>;
+
+  getConfig.toJSON = () => {
+    const result = {};
+
+    for (const [key, { value, secret }] of map.entries()) {
+      const keys = key.split('.');
+      let current = result;
+
+      for (let i = 0; i < keys.length; i++) {
+        const k = keys[i];
+        if (i === keys.length - 1) {
+          current[k] = maskSecretValue(value, secret);
+        } else {
+          if (!(k in current)) {
+            current[k] = {};
+          }
+          current = current[k];
+        }
+      }
+    }
+
+    return result;
+  };
+
+  return getConfig;
 };


### PR DESCRIPTION
- Adds option to serialize the configuration object for logging and/or debugging purposes. 
- Adds a secret boolean flag to ensure sensitive information are not logged when using `config.toJSON()`.